### PR TITLE
Improve performance by determining bookmark domain name via sqlite

### DIFF
--- a/rofi_firefox_bookmarks.sh
+++ b/rofi_firefox_bookmarks.sh
@@ -30,12 +30,11 @@ create_backup() {
 
 # process bookmarks
 process_bookmarks() {
-  query="select p.title, p.url, b.id from moz_bookmarks as b left outer join moz_places as p on b.fk=p.id where b.type = 1 and p.hidden=0 and b.title not null" #  and parent=$1
-  $sqlite_path $sqlite_params "$places_backup" "$query" | while IFS=^ read title url id; do
+  query="select b.title, p.url, b.id, SUBSTR(SUBSTR(p.url, INSTR(url, '//') + 2), 0, INSTR(SUBSTR(p.url, INSTR(p.url, '//') + 2), '/')) as domain from moz_bookmarks as b left outer join moz_places as p on b.fk=p.id where b.type = 1 and p.hidden=0 and b.title not null" #  and parent=$1
+  $sqlite_path $sqlite_params "$places_backup" "$query" | while IFS=^ read title url id domain; do
     if [ -z "$title" ]; then
       title="$url"
     fi
-    domain="$(echo "$url" | awk -F/ '{print $3}')"
     printf "%-500s {id:%s}\n" "$title [$domain]" "$id"
   done
 }

--- a/rofi_firefox_tree.sh
+++ b/rofi_firefox_tree.sh
@@ -76,12 +76,11 @@ process_folder() {
 # process bookmarks
 process_bookmarks() {
   if [ "$#" = 1 ] && [ -n "$1" ]; then
-    query="select b.title, p.url, b.id from moz_bookmarks as b left outer join moz_places as p on b.fk=p.id where b.type = 1 and p.hidden=0 and b.title not null and parent=$1"
-    $sqlite_path $sqlite_params "$places_backup" "$query" | while IFS=^ read title url id; do
+    query="select b.title, p.url, b.id, SUBSTR(SUBSTR(p.url, INSTR(url, '//') + 2), 0, INSTR(SUBSTR(p.url, INSTR(p.url, '//') + 2), '/')) from moz_bookmarks as b left outer join moz_places as p on b.fk=p.id where b.type = 1 and p.hidden=0 and b.title not null and parent=$1"
+	$sqlite_path $sqlite_params "$places_backup" "$query" | while IFS=^ read title url id domain; do
       if [ -z "$title" ]; then
         title="$url"
       fi
-      domain="$(echo "$url" | awk -F/ '{print $3}')"
       printf "%-500s {id:%s}\n" "$title [$domain]" "$id"
     done
   fi


### PR DESCRIPTION
Before there was a short delay of 300ms-500ms on my machine before the rofi window opened (~100 bookmarks). This was caused by determining the domain name through the url with awk. I changed that so this determination is done via sqlite as described here https://stackoverflow.com/questions/52728573/extract-the-site-domain-name-from-a-url-in-sqlite3. This reduced the delay down to 20ms-30ms. 

I compared the output of the old version with the new version and there were no differences among my ~100 bookmarks. 