### PR TITLE
Fix rofi not exiting when first starting Firefox

### DIFF
--- a/rofi_firefox_bookmarks.sh
+++ b/rofi_firefox_bookmarks.sh
@@ -45,7 +45,7 @@ process_bookmark() {
     id="$(echo $1 | sed "s|.*{id:\(.*\)}$|\1|")"
     query="select p.url from moz_bookmarks as b left outer join moz_places as p on b.fk=p.id where b.type = 1 and p.hidden=0 and b.title not null and b.id=$id"
     url="$($sqlite_path $sqlite_params "$places_backup" "$query")"
-    $browser_path "$url"
+    nohup $browser_path "$url" >/dev/null 2>&1 &
   fi
 }
 

--- a/rofi_firefox_tree.sh
+++ b/rofi_firefox_tree.sh
@@ -92,7 +92,7 @@ process_bookmark() {
     id="$(echo $1 | sed "s|.*{id:\(.*\)}$|\1|")"
     query="select p.url from moz_bookmarks as b left outer join moz_places as p on b.fk=p.id where b.type = 1 and p.hidden=0 and b.title not null and b.id=$id"
     url="$($sqlite_path $sqlite_params "$places_backup" "$query")"
-    $browser_path "$url"
+    nohup $browser_path "$url" >/dev/null 2>&1 &
   fi
 }
 


### PR DESCRIPTION
When Firefox is not started and the script is used the rofi process will launch Firefox as a child process which will only finish when Firefox is closed. This causes rofi to still be opened since Firefox is still running. This results in a rofi "freeze" and suppression of keyboard input. I had to change to a different tty to kill the process. This version now uses `nohup` to avoid this. 